### PR TITLE
Update sync services to fetch config per request

### DIFF
--- a/aptoosh-frontend/src/lib/syncService.ts
+++ b/aptoosh-frontend/src/lib/syncService.ts
@@ -79,14 +79,13 @@ export interface SellerOrdersResponse {
   data: BuyerOrderGroup[]
 }
 
-const config = getCurrentConfig();
-
 /**
  * Fetches products for a specific wallet address
  */
 export async function fetchProductsForWallet(walletAddress: string): Promise<ProductData[]> {
   try {
-    const response = await fetch(`${config.apiUrl}/products/${walletAddress}`)
+    const {apiUrl} = getCurrentConfig()
+    const response = await fetch(`${apiUrl}/products/${walletAddress}`)
 
     if (!response.ok) {
       if (response.status === 404) {
@@ -126,7 +125,8 @@ export async function fetchUserCatalogues(walletAddress: string): Promise<Produc
  */
 export async function fetchSellerOrders(sellerWallet: string): Promise<Order[]> {
   try {
-    const response = await fetch(`${config.apiUrl}/orders/seller/${sellerWallet}`)
+    const {apiUrl} = getCurrentConfig()
+    const response = await fetch(`${apiUrl}/orders/seller/${sellerWallet}`)
 
     if (!response.ok) {
       if (response.status === 404) {

--- a/aptoosh-seller/src/lib/syncService.ts
+++ b/aptoosh-seller/src/lib/syncService.ts
@@ -79,15 +79,14 @@ export interface SellerOrdersResponse {
   data: BuyerOrderGroup[]
 }
 
-const config = getCurrentConfig();
-
 
 /**
  * Fetches products for a specific wallet address
  */
 export async function fetchProductsForWallet(walletAddress: string): Promise<ProductData[]> {
   try {
-    const response = await fetch(`${config.apiUrl}/products/${walletAddress}`)
+    const {apiUrl} = getCurrentConfig()
+    const response = await fetch(`${apiUrl}/products/${walletAddress}`)
 
     if (!response.ok) {
       if (response.status === 404) {
@@ -127,7 +126,8 @@ export async function fetchUserCatalogues(walletAddress: string): Promise<Produc
  */
 export async function fetchSellerOrders(sellerWallet: string): Promise<Order[]> {
   try {
-    const response = await fetch(`${config.apiUrl}/orders/seller/${sellerWallet}`)
+    const {apiUrl} = getCurrentConfig()
+    const response = await fetch(`${apiUrl}/orders/seller/${sellerWallet}`)
 
     if (!response.ok) {
       if (response.status === 404) {


### PR DESCRIPTION
## Summary
- remove the module-level cached config from the frontend and seller sync services
- call `getCurrentConfig()` within each fetch helper so API requests honor the latest network selection

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d857ddef6c832a8df55285ef3849e3